### PR TITLE
Add ack-grep package

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -4,7 +4,7 @@
 # Required packages for Janus
 case node['platform']
 when "ubuntu", "debian"
-  default['janus']['packages'] = %w{ curl exuberant-ctags git-core libopenssl-ruby rake ruby-dev ruby vim vim-nox }
+  default['janus']['packages'] = %w{ curl exuberant-ctags git-core libopenssl-ruby rake ruby-dev ruby vim vim-nox ack-grep }
 end
 
 # List of users and home directory location

--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -7,7 +7,7 @@ Vagrant::Config.run do |config|
 
   # The url from where the 'config.vm.box' box will be fetched if it
   # doesn't already exist on the user's system.
-  # config.vm.box_url = "http://files.vagrantup.com/lucid64.box"
+  config.vm.box_url = "http://files.vagrantup.com/lucid64.box"
 
   # Update apt-get package list on vagrant box
   config.vm.provision :shell, :inline => "apt-get update -y"


### PR DESCRIPTION
I've added ack-grep package, which, I think, should be installed by default. Without it I cannot use Ack.vim plugin. 

You could find it on Janus Pre requisites https://github.com/carlhuda/janus/wiki/Pre-requisites page.
